### PR TITLE
Fixed a deadlock issue in arc read-write conflicts

### DIFF
--- a/module/zfs/arc.c
+++ b/module/zfs/arc.c
@@ -7068,7 +7068,7 @@ arc_write_done(zio_t *zio)
 	} else {
 		arc_hdr_clear_flags(hdr, ARC_FLAG_IO_IN_PROGRESS);
 	}
-
+        cv_broadcast(&hdr->b_l1hdr.b_cv);
 	ASSERT(!zfs_refcount_is_zero(&hdr->b_l1hdr.b_refcnt));
 	callback->awcb_done(zio, buf, callback->awcb_private);
 


### PR DESCRIPTION
  An existing deadlock scenario is when a call to arc_read goes inside the logic "if (HDR_IO_IN_PROGRESS(HDR)) " and the current state of ARC_FLAG_IO_IN_PROGRESS is not held by another arc_read, but by another writting thread.  The current code logic is that only other threads calling arc_read_done can wake up the thread currently waiting on cv_wait, causing a deadlock.  
 Fixing this method by far the easiest way to call cv_broadcast when calling arc_write_done.  But I think it's best to distinguish between read and read, read and write, write and write mutually exclusive behavior, rather than having a single lock in all cases, adding extra overhead and some uncertainty if you just repeat reads.

<!--- Please fill out the following template, which will help other contributors review your Pull Request. -->

<!--- Provide a general summary of your changes in the Title above -->

<!---
Documentation on ZFS Buildbot options can be found at
https://openzfs.github.io/openzfs-docs/Developer%20Resources/Buildbot%20Options.html
-->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->An existing deadlock scenario is when a call to arc_read goes inside the logic "if (HDR_IO_IN_PROGRESS(HDR)) " and the current state of ARC_FLAG_IO_IN_PROGRESS is not held by another arc_read, but by another writting thread.  The current code logic is that only other threads calling arc_read_done can wake up the thread currently waiting on cv_wait, causing a deadlock.  
<!--- If it fixes an open issue, please link to the issue here. -->
### Description
<!--- Describe your changes in detail -->Fixing this method by far the easiest way to call cv_broadcast when calling arc_write_done.  But I think it's best to distinguish between read and read, read and write, write and write mutually exclusive behavior, rather than having a single lock in all cases, adding extra overhead and some uncertainty if you just repeat reads.
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
<!--- Please think about using the draft PR feature if appropriate -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Library ABI change (libzfs, libzfs\_core, libnvpair, libuutil and libzfsbootenv)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the OpenZFS [code style requirements](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#coding-conventions).
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**contributing** document](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md).
- [ ] I have added [tests](https://github.com/openzfs/zfs/tree/master/tests) to cover my changes.
- [ ] I have run the ZFS Test Suite with this change applied.
- [ ] All commit messages are properly formatted and contain [`Signed-off-by`](https://github.com/openzfs/zfs/blob/master/.github/CONTRIBUTING.md#signed-off-by).
